### PR TITLE
Add Certificate Manager Laravel skeleton

### DIFF
--- a/certificate-manager/.env.example
+++ b/certificate-manager/.env.example
@@ -1,0 +1,12 @@
+APP_NAME=CertificateManager
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=certificate_manager
+DB_USERNAME=root
+DB_PASSWORD=

--- a/certificate-manager/README.md
+++ b/certificate-manager/README.md
@@ -1,0 +1,21 @@
+# Certificate Manager
+
+Simple Laravel 10 application for managing land certificates.
+
+## Installation
+
+```bash
+composer install
+cp .env.example .env
+php artisan key:generate
+php artisan migrate --seed
+npm install
+npm run build
+php artisan serve
+```
+
+## Features
+- Authentication with admin/user roles
+- CRUD management for users and land certificates
+- Activity logs for login/logout and CRUD actions
+- Tailwind CSS based UI

--- a/certificate-manager/app/Http/Controllers/ActivityLogController.php
+++ b/certificate-manager/app/Http/Controllers/ActivityLogController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ActivityLog;
+
+class ActivityLogController extends Controller
+{
+    public function index()
+    {
+        $logs = ActivityLog::latest()->paginate(20);
+        return view('logs.index', compact('logs'));
+    }
+}

--- a/certificate-manager/app/Http/Controllers/AuthController.php
+++ b/certificate-manager/app/Http/Controllers/AuthController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\ActivityLog;
+
+class AuthController extends Controller
+{
+    public function showLogin()
+    {
+        return view('auth.login');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+        if (Auth::attempt($credentials)) {
+            ActivityLog::create(['user_id' => Auth::id(), 'description' => 'login']);
+            $request->session()->regenerate();
+            return redirect()->intended('/');
+        }
+        return back()->withErrors(['email' => 'Invalid credentials']);
+    }
+
+    public function logout(Request $request)
+    {
+        ActivityLog::create(['user_id' => Auth::id(), 'description' => 'logout']);
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return redirect('/login');
+    }
+}

--- a/certificate-manager/app/Http/Controllers/CertificateController.php
+++ b/certificate-manager/app/Http/Controllers/CertificateController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Certificate;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class CertificateController extends Controller
+{
+    public function index(Request $request)
+    {
+        $search = $request->query('search');
+        $query = Certificate::query();
+        if ($search) {
+            $query->where('kode', 'like', "%{$search}%")
+                  ->orWhere('nama_pemegang', 'like', "%{$search}%");
+        }
+        $certificates = $query->paginate(10);
+
+        return view('certificates.index', compact('certificates', 'search'));
+    }
+
+    public function create()
+    {
+        return view('certificates.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'kode' => 'required|unique:certificates,kode',
+            'nama_pemegang' => 'required',
+            'surat_hak' => 'required',
+            'no_sertifikat' => 'required',
+            'lokasi_tanah' => 'required',
+            'luas_m2' => 'required|numeric',
+        ]);
+        $cert = Certificate::create($data);
+        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'create certificate '.$cert->id]);
+        return redirect()->route('certificates.index');
+    }
+
+    public function edit(Certificate $certificate)
+    {
+        return view('certificates.edit', compact('certificate'));
+    }
+
+    public function update(Request $request, Certificate $certificate)
+    {
+        $data = $request->validate([
+            'kode' => 'required|unique:certificates,kode,' . $certificate->id,
+            'nama_pemegang' => 'required',
+            'surat_hak' => 'required',
+            'no_sertifikat' => 'required',
+            'lokasi_tanah' => 'required',
+            'luas_m2' => 'required|numeric',
+        ]);
+        $certificate->update($data);
+        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'update certificate '.$certificate->id]);
+        return redirect()->route('certificates.index');
+    }
+
+    public function destroy(Certificate $certificate)
+    {
+        $certificate->delete();
+        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'delete certificate '.$certificate->id]);
+        return redirect()->route('certificates.index');
+    }
+}

--- a/certificate-manager/app/Http/Controllers/Controller.php
+++ b/certificate-manager/app/Http/Controllers/Controller.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    protected function middleware($middleware, array $options = [])
+    {
+        // Placeholder
+    }
+}

--- a/certificate-manager/app/Http/Controllers/UserController.php
+++ b/certificate-manager/app/Http/Controllers/UserController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Models\ActivityLog;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        $users = User::paginate(10);
+        return view('users.index', compact('users'));
+    }
+
+    public function create()
+    {
+        return view('users.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|unique:users,name',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|min:6',
+            'role' => 'required|in:admin,user',
+        ]);
+        $data['password'] = bcrypt($data['password']);
+        $user = User::create($data);
+        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'create user '.$user->id]);
+        return redirect()->route('users.index');
+    }
+
+    public function edit(User $user)
+    {
+        return view('users.edit', compact('user'));
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $data = $request->validate([
+            'name' => 'required|unique:users,name,' . $user->id,
+            'email' => 'required|email|unique:users,email,' . $user->id,
+            'password' => 'nullable|min:6',
+            'role' => 'required|in:admin,user',
+        ]);
+        if ($data['password']) {
+            $data['password'] = bcrypt($data['password']);
+        } else {
+            unset($data['password']);
+        }
+        $user->update($data);
+        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'update user '.$user->id]);
+        return redirect()->route('users.index');
+    }
+
+    public function destroy(User $user)
+    {
+        $user->delete();
+        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'delete user '.$user->id]);
+        return redirect()->route('users.index');
+    }
+}

--- a/certificate-manager/app/Http/Kernel.php
+++ b/certificate-manager/app/Http/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use App\Http\Middleware\RoleMiddleware;
+
+class Kernel extends HttpKernel
+{
+    protected $middlewareGroups = [
+        'web' => [
+            // ... Laravel's default web middleware
+        ],
+    ];
+
+    protected $routeMiddleware = [
+        'role' => RoleMiddleware::class,
+    ];
+}

--- a/certificate-manager/app/Http/Middleware/RoleMiddleware.php
+++ b/certificate-manager/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class RoleMiddleware
+{
+    public function handle($request, Closure $next, $role)
+    {
+        if (!Auth::check() || Auth::user()->role !== $role) {
+            abort(403);
+        }
+        return $next($request);
+    }
+}

--- a/certificate-manager/app/Models/ActivityLog.php
+++ b/certificate-manager/app/Models/ActivityLog.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class ActivityLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'description',
+    ];
+}

--- a/certificate-manager/app/Models/Certificate.php
+++ b/certificate-manager/app/Models/Certificate.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Certificate extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'kode',
+        'nama_pemegang',
+        'surat_hak',
+        'no_sertifikat',
+        'lokasi_tanah',
+        'luas_m2',
+    ];
+}

--- a/certificate-manager/bootstrap/app.php
+++ b/certificate-manager/bootstrap/app.php
@@ -1,0 +1,7 @@
+<?php
+
+// Placeholder bootstrap file
+
+return new Illuminate\Foundation\Application(
+    dirname(__DIR__)
+);

--- a/certificate-manager/composer.json
+++ b/certificate-manager/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "certificate-manager",
+    "description": "Certificate Manager Laravel 10 application",
+    "type": "project",
+    "require": {
+        "php": "^8.1",
+        "laravel/framework": "^10.0",
+        "laravel/breeze": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/certificate-manager/config/app.php
+++ b/certificate-manager/config/app.php
@@ -1,0 +1,4 @@
+<?php
+return [
+    'name' => env('APP_NAME', 'CertificateManager'),
+];

--- a/certificate-manager/database/migrations/2024_01_01_000000_create_users_table.php
+++ b/certificate-manager/database/migrations/2024_01_01_000000_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('role')->default('user');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/certificate-manager/database/migrations/2024_01_01_000100_create_certificates_table.php
+++ b/certificate-manager/database/migrations/2024_01_01_000100_create_certificates_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('certificates', function (Blueprint $table) {
+            $table->id();
+            $table->string('kode')->unique();
+            $table->string('nama_pemegang');
+            $table->string('surat_hak');
+            $table->string('no_sertifikat');
+            $table->string('lokasi_tanah');
+            $table->integer('luas_m2');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('certificates');
+    }
+};

--- a/certificate-manager/database/migrations/2024_01_01_000200_create_activity_logs_table.php
+++ b/certificate-manager/database/migrations/2024_01_01_000200_create_activity_logs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('description');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_logs');
+    }
+};

--- a/certificate-manager/database/seeders/DatabaseSeeder.php
+++ b/certificate-manager/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::create([
+            'name' => 'admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+            'role' => 'admin',
+        ]);
+    }
+}

--- a/certificate-manager/public/index.php
+++ b/certificate-manager/public/index.php
@@ -1,0 +1,8 @@
+<?php
+
+// Placeholder for Laravel public/index.php
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+// handle request

--- a/certificate-manager/resources/views/auth/login.blade.php
+++ b/certificate-manager/resources/views/auth/login.blade.php
@@ -1,0 +1,11 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Login</h1>
+<form action="{{ route('login') }}" method="post" class="space-y-2">
+    @csrf
+    <input type="email" name="email" placeholder="Email" class="border w-full" />
+    <input type="password" name="password" placeholder="Password" class="border w-full" />
+    <button class="bg-blue-500 text-white px-3 py-1">Login</button>
+</form>
+@endsection

--- a/certificate-manager/resources/views/certificates/create.blade.php
+++ b/certificate-manager/resources/views/certificates/create.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Tambah Sertifikat</h1>
+<form action="{{ route('certificates.store') }}" method="post" class="space-y-2">
+    @csrf
+    <input type="text" name="kode" placeholder="Kode" class="border w-full" />
+    <input type="text" name="nama_pemegang" placeholder="Nama Pemegang" class="border w-full" />
+    <input type="text" name="surat_hak" placeholder="Surat Hak" class="border w-full" />
+    <input type="text" name="no_sertifikat" placeholder="No Sertifikat" class="border w-full" />
+    <input type="text" name="lokasi_tanah" placeholder="Lokasi" class="border w-full" />
+    <input type="number" name="luas_m2" placeholder="Luas m2" class="border w-full" />
+    <button class="bg-blue-500 text-white px-3 py-1">Simpan</button>
+</form>
+@endsection

--- a/certificate-manager/resources/views/certificates/edit.blade.php
+++ b/certificate-manager/resources/views/certificates/edit.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Edit Sertifikat</h1>
+<form action="{{ route('certificates.update', $certificate) }}" method="post" class="space-y-2">
+    @csrf
+    @method('put')
+    <input type="text" name="kode" value="{{ $certificate->kode }}" class="border w-full" />
+    <input type="text" name="nama_pemegang" value="{{ $certificate->nama_pemegang }}" class="border w-full" />
+    <input type="text" name="surat_hak" value="{{ $certificate->surat_hak }}" class="border w-full" />
+    <input type="text" name="no_sertifikat" value="{{ $certificate->no_sertifikat }}" class="border w-full" />
+    <input type="text" name="lokasi_tanah" value="{{ $certificate->lokasi_tanah }}" class="border w-full" />
+    <input type="number" name="luas_m2" value="{{ $certificate->luas_m2 }}" class="border w-full" />
+    <button class="bg-blue-500 text-white px-3 py-1">Simpan</button>
+</form>
+@endsection

--- a/certificate-manager/resources/views/certificates/index.blade.php
+++ b/certificate-manager/resources/views/certificates/index.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Sertifikat</h1>
+<form method="get" class="mb-4">
+    <input type="text" name="search" value="{{ $search }}" placeholder="Search" class="border p-1" />
+    <button class="bg-blue-500 text-white px-2 py-1">Cari</button>
+</form>
+<table class="table-auto w-full mb-4">
+    <thead>
+        <tr>
+            <th>Kode</th>
+            <th>Nama Pemegang</th>
+            <th>No Sertifikat</th>
+            <th>Luas (m2)</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($certificates as $c)
+        <tr>
+            <td>{{ $c->kode }}</td>
+            <td>{{ $c->nama_pemegang }}</td>
+            <td>{{ $c->no_sertifikat }}</td>
+            <td>{{ $c->luas_m2 }}</td>
+            <td>
+                <a href="{{ route('certificates.edit', $c) }}" class="text-blue-500">Edit</a>
+                <form action="{{ route('certificates.destroy', $c) }}" method="post" style="display:inline">
+                    @csrf
+                    @method('delete')
+                    <button class="text-red-500" onclick="return confirm('Delete?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+{{ $certificates->links() }}
+@endsection

--- a/certificate-manager/resources/views/layouts/app.blade.php
+++ b/certificate-manager/resources/views/layouts/app.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ config('app.name') }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="flex">
+    <aside class="w-48 bg-gray-200 min-h-screen p-4">
+        <nav class="space-y-2">
+            <a href="/" class="block">Dashboard</a>
+            <a href="/certificates" class="block">Sertifikat</a>
+            <a href="/users" class="block">User</a>
+            <a href="/logs" class="block">Log</a>
+        </nav>
+    </aside>
+    <main class="flex-1 p-6">
+        @yield('content')
+    </main>
+</body>
+</html>

--- a/certificate-manager/resources/views/logs/index.blade.php
+++ b/certificate-manager/resources/views/logs/index.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Activity Logs</h1>
+<table class="table-auto w-full">
+    <thead>
+        <tr>
+            <th>User</th>
+            <th>Description</th>
+            <th>Date</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($logs as $log)
+        <tr>
+            <td>{{ $log->user->name ?? '-' }}</td>
+            <td>{{ $log->description }}</td>
+            <td>{{ $log->created_at }}</td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+{{ $logs->links() }}
+@endsection

--- a/certificate-manager/resources/views/users/create.blade.php
+++ b/certificate-manager/resources/views/users/create.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Tambah User</h1>
+<form action="{{ route('users.store') }}" method="post" class="space-y-2">
+    @csrf
+    <input type="text" name="name" placeholder="Name" class="border w-full" />
+    <input type="email" name="email" placeholder="Email" class="border w-full" />
+    <input type="password" name="password" placeholder="Password" class="border w-full" />
+    <select name="role" class="border w-full">
+        <option value="user">User</option>
+        <option value="admin">Admin</option>
+    </select>
+    <button class="bg-blue-500 text-white px-3 py-1">Simpan</button>
+</form>
+@endsection

--- a/certificate-manager/resources/views/users/edit.blade.php
+++ b/certificate-manager/resources/views/users/edit.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Edit User</h1>
+<form action="{{ route('users.update', $user) }}" method="post" class="space-y-2">
+    @csrf
+    @method('put')
+    <input type="text" name="name" value="{{ $user->name }}" class="border w-full" />
+    <input type="email" name="email" value="{{ $user->email }}" class="border w-full" />
+    <input type="password" name="password" placeholder="Password" class="border w-full" />
+    <select name="role" class="border w-full">
+        <option value="user" {{ $user->role == 'user' ? 'selected' : '' }}>User</option>
+        <option value="admin" {{ $user->role == 'admin' ? 'selected' : '' }}>Admin</option>
+    </select>
+    <button class="bg-blue-500 text-white px-3 py-1">Simpan</button>
+</form>
+@endsection

--- a/certificate-manager/resources/views/users/index.blade.php
+++ b/certificate-manager/resources/views/users/index.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold mb-4">Users</h1>
+<table class="table-auto w-full mb-4">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Created</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($users as $user)
+        <tr>
+            <td>{{ $user->name }}</td>
+            <td>{{ $user->email }}</td>
+            <td>{{ $user->role }}</td>
+            <td>{{ $user->created_at->format('Y-m-d') }}</td>
+            <td>
+                <a href="{{ route('users.edit', $user) }}" class="text-blue-500">Edit</a>
+                <form action="{{ route('users.destroy', $user) }}" method="post" style="display:inline">
+                    @csrf
+                    @method('delete')
+                    <button class="text-red-500" onclick="return confirm('Delete?')">Delete</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+{{ $users->links() }}
+@endsection

--- a/certificate-manager/resources/views/welcome.blade.php
+++ b/certificate-manager/resources/views/welcome.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.app')
+
+@section('content')
+<h1 class="text-xl font-bold">Dashboard</h1>
+<p>Welcome to Certificate Manager.</p>
+@endsection

--- a/certificate-manager/routes/web.php
+++ b/certificate-manager/routes/web.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\UserController;
+use App\Http\Controllers\CertificateController;
+use App\Http\Controllers\ActivityLogController;
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+Route::get('login', [AuthController::class, 'showLogin'])->name('login');
+Route::post('login', [AuthController::class, 'login']);
+Route::post('logout', [AuthController::class, 'logout'])->name('logout');
+
+Route::middleware('auth')->group(function () {
+    Route::resource('certificates', CertificateController::class);
+    Route::resource('users', UserController::class)->middleware('role:admin');
+    Route::get('logs', [ActivityLogController::class, 'index'])->middleware('role:admin');
+});
+
+auth();
+
+


### PR DESCRIPTION
## Summary
- add `certificate-manager` project skeleton
- provide migrations and seeders
- implement basic controllers, models, routes, and Tailwind-based views
- include README with install instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685272c75554832ca16b586e050bf175