### PR TITLE
Fix syntax error in CertificateController

### DIFF
--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -65,8 +65,12 @@ class CertificateController extends Controller
     public function destroy(Certificate $certificate)
     {
         $certificate->delete();
-        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'delete certificate '.$certificate->id]);
-      main
+
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'description' => 'delete certificate '.$certificate->id,
+        ]);
+
         return redirect()->route('certificates.index');
     }
 }


### PR DESCRIPTION
## Summary
- remove stray `main` token
- reformat activity log call in `destroy`

## Testing
- `composer test` *(fails: could not find driver sqlite)*

------
https://chatgpt.com/codex/tasks/task_e_6852a43decfc832cac5a4ddb705862a1