### PR TITLE
Fix routes and enable tests

### DIFF
--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -65,8 +65,12 @@ class CertificateController extends Controller
     public function destroy(Certificate $certificate)
     {
         $certificate->delete();
-        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'delete certificate '.$certificate->id]);
-      main
+
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'description' => 'delete certificate '.$certificate->id,
+        ]);
+
         return redirect()->route('certificates.index');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,30 +6,20 @@ use App\Http\Controllers\CertificateController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\ActivityLogController;
 
-// Redirect root URL to the certificate manager
-Route::redirect('/', '/certificates');
+// Show welcome page on root URL
+Route::view('/', 'welcome');
 
 Route::middleware('auth')->group(function () {
     Route::resource('certificates', CertificateController::class);
     Route::resource('users', UserController::class)->middleware('role:admin');
     Route::get('logs', [ActivityLogController::class, 'index'])->middleware('role:admin');
+
+    Route::middleware('verified')->group(function () {
+        Route::get('dashboard', function () {
+            return Inertia::render('dashboard');
+        })->name('dashboard');
+    });
 });
 
+require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';
-
-Route::middleware('auth')->group(function () {
-    Route::resource('certificates', CertificateController::class);
-    Route::resource('users', UserController::class)->middleware('role:admin');
-    Route::get('logs', [ActivityLogController::class, 'index'])->middleware('role:admin');
-});
-
-require __DIR__.'/auth.php';
-
-#Route::middleware(['auth', 'verified'])->group(function () {
-#    Route::get('dashboard', function () {
-#        return Inertia::render('dashboard');
-#    })->name('dashboard');
-#});
-
-#require __DIR__.'/settings.php';
-#require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- un-comment settings routes and dashboard
- serve welcome page on root URL

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6852a43decfc832cac5a4ddb705862a1