### PR TITLE
Fix login page and certificate delete route

### DIFF
--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -62,11 +62,15 @@ class CertificateController extends Controller
     }
 
 
-    public function destroy(Certificate $certificate)
+    public function destroy(Request $request, Certificate $certificate)
     {
         $certificate->delete();
-        ActivityLog::create(['user_id' => $request->user()->id, 'description' => 'delete certificate '.$certificate->id]);
-      main
+
+        ActivityLog::create([
+            'user_id' => $request->user()->id,
+            'description' => 'delete certificate '.$certificate->id,
+        ]);
+
         return redirect()->route('certificates.index');
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,30 +6,20 @@ use App\Http\Controllers\CertificateController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\ActivityLogController;
 
-// Redirect root URL to the certificate manager
-Route::redirect('/', '/certificates');
+// Redirect visitors to the login page
+Route::redirect('/', '/login');
 
 Route::middleware('auth')->group(function () {
     Route::resource('certificates', CertificateController::class);
     Route::resource('users', UserController::class)->middleware('role:admin');
     Route::get('logs', [ActivityLogController::class, 'index'])->middleware('role:admin');
+
+    Route::middleware('verified')->group(function () {
+        Route::get('dashboard', function () {
+            return Inertia::render('dashboard');
+        })->name('dashboard');
+    });
 });
 
+require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';
-
-Route::middleware('auth')->group(function () {
-    Route::resource('certificates', CertificateController::class);
-    Route::resource('users', UserController::class)->middleware('role:admin');
-    Route::get('logs', [ActivityLogController::class, 'index'])->middleware('role:admin');
-});
-
-require __DIR__.'/auth.php';
-
-#Route::middleware(['auth', 'verified'])->group(function () {
-#    Route::get('dashboard', function () {
-#        return Inertia::render('dashboard');
-#    })->name('dashboard');
-#});
-
-#require __DIR__.'/settings.php';
-#require __DIR__.'/auth.php';

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,7 +1,7 @@
 <?php
 
-it('returns a successful response', function () {
+it('redirects the root URL to the login page', function () {
     $response = $this->get('/');
 
-    $response->assertStatus(200);
+    $response->assertRedirect('/login');
 });


### PR DESCRIPTION
## Summary
- redirect `/` to the login page so registration is offered immediately
- correct `destroy` signature in `CertificateController`
- update example test for new behavior

## Testing
- `composer test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a43decfc832cac5a4ddb705862a1