### PR TITLE
Show certificate preview on dashboard

### DIFF
--- a/app/Http/Controllers/CertificateController.php
+++ b/app/Http/Controllers/CertificateController.php
@@ -8,6 +8,20 @@ use Illuminate\Http\Request;
 
 class CertificateController extends Controller
 {
+    /**
+     * Get a limited list of certificates for dashboard preview.
+     */
+    public static function preview(?string $search = null, int $limit = 5)
+    {
+        $query = Certificate::query();
+
+        if ($search) {
+            $query->where('kode', 'like', "%{$search}%")
+                  ->orWhere('nama_pemegang', 'like', "%{$search}%");
+        }
+
+        return $query->latest()->take($limit)->get();
+    }
     public function index(Request $request)
     {
         $search = $request->query('search');

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\CertificateController;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class DashboardController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $search = $request->query('search');
+        $certificates = CertificateController::preview($search);
+
+        return Inertia::render('dashboard', [
+            'certificates' => $certificates,
+            'search' => $search,
+        ]);
+    }
+}

--- a/resources/js/components/certificate-preview-table.tsx
+++ b/resources/js/components/certificate-preview-table.tsx
@@ -1,0 +1,32 @@
+export interface Certificate {
+    id: number;
+    kode: string;
+    nama_pemegang: string;
+    no_sertifikat: string;
+    luas_m2: number;
+}
+
+export default function CertificatePreviewTable({ certificates }: { certificates: Certificate[] }) {
+    return (
+        <table className="w-full text-sm">
+            <thead>
+                <tr className="text-left">
+                    <th className="py-2">Kode</th>
+                    <th className="py-2">Nama Pemegang</th>
+                    <th className="py-2">No Sertifikat</th>
+                    <th className="py-2">Luas (m2)</th>
+                </tr>
+            </thead>
+            <tbody>
+                {certificates.map((c) => (
+                    <tr key={c.id} className="border-b last:border-none">
+                        <td className="py-2">{c.kode}</td>
+                        <td className="py-2">{c.nama_pemegang}</td>
+                        <td className="py-2">{c.no_sertifikat}</td>
+                        <td className="py-2">{c.luas_m2}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,6 +1,10 @@
 import AppLayout from '@/layouts/app-layout';
-import { type BreadcrumbItem } from '@/types';
-import { Head, Link } from '@inertiajs/react';
+import CertificatePreviewTable, { type Certificate } from '@/components/certificate-preview-table';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -9,14 +13,38 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
+interface PageProps extends SharedData {
+    certificates: Certificate[];
+    search?: string;
+}
+
 export default function Dashboard() {
+    const { certificates, search } = usePage<PageProps>().props;
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 p-4">
-                <Link href="/certificates" className="block rounded-lg border p-6 text-center hover:bg-gray-50 dark:hover:bg-neutral-800">
-                    Sertifikat
-                </Link>
+                <Card className="sm:col-span-2 lg:col-span-2">
+                    <CardHeader>
+                        <CardTitle>Sertifikat</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <form method="get" className="flex flex-wrap gap-2">
+                            <Input name="search" defaultValue={search ?? ''} placeholder="Cari sertifikat..." />
+                            <Button type="submit">Cari</Button>
+                            <Button asChild variant="secondary">
+                                <Link href="/certificates/create">Tambah Sertifikat</Link>
+                            </Button>
+                        </form>
+                        <CertificatePreviewTable certificates={certificates} />
+                        <div className="text-right">
+                            <Link href="/certificates" className="text-primary hover:underline">
+                                Lihat Semua
+                            </Link>
+                        </div>
+                    </CardContent>
+                </Card>
                 <Link href="/users" className="block rounded-lg border p-6 text-center hover:bg-gray-50 dark:hover:bg-neutral-800">
                     User
                 </Link>

--- a/resources/views/certificates/index.blade.php
+++ b/resources/views/certificates/index.blade.php
@@ -2,11 +2,6 @@
 
 @section('content')
 <h1 class="text-xl font-bold mb-4">Sertifikat</h1>
-<form method="get" class="mb-4">
-    <input type="text" name="search" value="{{ $search }}" placeholder="Search" class="border p-1" />
-    <button class="bg-blue-500 text-white px-2 py-1">Cari</button>
-</form>
-<a href="{{ route('certificates.create') }}" class="bg-green-500 text-white px-2 py-1 mb-4 inline-block">Tambah Sertifikat</a>
 <table class="table-auto w-full mb-4">
     <thead>
         <tr>
@@ -36,6 +31,5 @@
         @endforeach
     </tbody>
 </table>
-</div>
 {{ $certificates->links() }}
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,9 +17,7 @@ Route::middleware('auth')->group(function () {
     Route::get('logs', [ActivityLogController::class, 'index'])->middleware('role:admin');
 
     Route::middleware('verified')->group(function () {
-        Route::get('dashboard', function () {
-            return Inertia::render('dashboard');
-        })->name('dashboard');
+        Route::get('dashboard', \App\Http\Controllers\DashboardController::class)->name('dashboard');
     });
 });
 


### PR DESCRIPTION
## Summary
- add `preview` helper in `CertificateController`
- create `DashboardController` to render dashboard with certificates
- route dashboard through controller
- add `CertificatePreviewTable` component
- update dashboard page to display certificate list and search
- simplify certificate index page

## Testing
- `npm run lint`
- `npm run types`
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6852ee0cf1ec832c81aebf1fb4d06bd4