### PR TITLE
Simplify dashboard layout

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ActivityLog;
+use App\Models\Certificate;
+use App\Models\User;
+use Inertia\Inertia;
+
+class DashboardController extends Controller
+{
+    public function __invoke()
+    {
+        $stats = [
+            'certificates' => Certificate::count(),
+            'users' => User::count(),
+            'logs' => ActivityLog::count(),
+        ];
+
+        return Inertia::render('dashboard', [
+            'stats' => $stats,
+        ]);
+    }
+}

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -4,7 +4,7 @@ import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-react';
+import { BookOpen, Folder, LayoutGrid, FileText, Users as UsersIcon, List } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -12,6 +12,21 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: '/dashboard',
         icon: LayoutGrid,
+    },
+    {
+        title: 'Certificates',
+        href: '/certificates',
+        icon: FileText,
+    },
+    {
+        title: 'Users',
+        href: '/users',
+        icon: UsersIcon,
+    },
+    {
+        title: 'Logs',
+        href: '/logs',
+        icon: List,
     },
 ];
 

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,6 +1,7 @@
 import AppLayout from '@/layouts/app-layout';
-import { type BreadcrumbItem } from '@/types';
-import { Head, Link } from '@inertiajs/react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, Link, usePage } from '@inertiajs/react';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -9,20 +10,60 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
+interface PageProps extends SharedData {
+    stats: {
+        certificates: number;
+        users: number;
+        logs: number;
+    };
+}
+
 export default function Dashboard() {
+    const { stats } = usePage<PageProps>().props;
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Dashboard" />
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 p-4">
-                <Link href="/certificates" className="block rounded-lg border p-6 text-center hover:bg-gray-50 dark:hover:bg-neutral-800">
-                    Sertifikat
-                </Link>
-                <Link href="/users" className="block rounded-lg border p-6 text-center hover:bg-gray-50 dark:hover:bg-neutral-800">
-                    User
-                </Link>
-                <Link href="/logs" className="block rounded-lg border p-6 text-center hover:bg-gray-50 dark:hover:bg-neutral-800">
-                    Log
-                </Link>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Sertifikat</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-3xl font-bold">{stats.certificates}</p>
+                        <div className="mt-2">
+                            <Link href="/certificates" className="text-primary hover:underline text-sm">
+                                View All
+                            </Link>
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>User</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-3xl font-bold">{stats.users}</p>
+                        <div className="mt-2">
+                            <Link href="/users" className="text-primary hover:underline text-sm">
+                                View All
+                            </Link>
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Log</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <p className="text-3xl font-bold">{stats.logs}</p>
+                        <div className="mt-2">
+                            <Link href="/logs" className="text-primary hover:underline text-sm">
+                                View All
+                            </Link>
+                        </div>
+                    </CardContent>
+                </Card>
             </div>
         </AppLayout>
     );

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,9 +17,7 @@ Route::middleware('auth')->group(function () {
     Route::get('logs', [ActivityLogController::class, 'index'])->middleware('role:admin');
 
     Route::middleware('verified')->group(function () {
-        Route::get('dashboard', function () {
-            return Inertia::render('dashboard');
-        })->name('dashboard');
+        Route::get('dashboard', \App\Http\Controllers\DashboardController::class)->name('dashboard');
     });
 });
 


### PR DESCRIPTION
## Summary
- compute certificate/user/log counts in a dashboard controller
- add sidebar links for Certificates, Users and Logs
- show only summary cards on the dashboard
- restore search form and add button on certificates page
- remove preview table component

## Testing
- `npm run lint`
- `npm run types`
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6852ee0cf1ec832c81aebf1fb4d06bd4