### PR TITLE
Improve dark mode styling across certificates UI

### DIFF
--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -5,7 +5,6 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { NavigationMenu, NavigationMenuItem, NavigationMenuList, navigationMenuTriggerStyle } from '@/components/ui/navigation-menu';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { UserMenuContent } from '@/components/user-menu-content';
 import { useInitials } from '@/hooks/use-initials';
 import { cn } from '@/lib/utils';
@@ -23,7 +22,6 @@ const mainNavItems: NavItem[] = [
     },
 ];
 
-const rightNavItems: NavItem[] = [];
 
 const activeItemStyles = 'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100';
 

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -11,7 +11,7 @@ import { useInitials } from '@/hooks/use-initials';
 import { cn } from '@/lib/utils';
 import { type BreadcrumbItem, type NavItem, type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-react';
+import { LayoutGrid, Menu, Search } from 'lucide-react';
 import AppLogo from './app-logo';
 import AppLogoIcon from './app-logo-icon';
 
@@ -23,18 +23,7 @@ const mainNavItems: NavItem[] = [
     },
 ];
 
-const rightNavItems: NavItem[] = [
-    {
-        title: 'Repository',
-        href: 'https://github.com/laravel/react-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits#react',
-        icon: BookOpen,
-    },
-];
+const rightNavItems: NavItem[] = [];
 
 const activeItemStyles = 'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100';
 
@@ -74,20 +63,6 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                                             ))}
                                         </div>
 
-                                        <div className="flex flex-col space-y-4">
-                                            {rightNavItems.map((item) => (
-                                                <a
-                                                    key={item.title}
-                                                    href={item.href}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    className="flex items-center space-x-2 font-medium"
-                                                >
-                                                    {item.icon && <Icon iconNode={item.icon} className="h-5 w-5" />}
-                                                    <span>{item.title}</span>
-                                                </a>
-                                            ))}
-                                        </div>
                                     </div>
                                 </div>
                             </SheetContent>
@@ -129,28 +104,6 @@ export function AppHeader({ breadcrumbs = [] }: AppHeaderProps) {
                             <Button variant="ghost" size="icon" className="group h-9 w-9 cursor-pointer">
                                 <Search className="!size-5 opacity-80 group-hover:opacity-100" />
                             </Button>
-                            <div className="hidden lg:flex">
-                                {rightNavItems.map((item) => (
-                                    <TooltipProvider key={item.title} delayDuration={0}>
-                                        <Tooltip>
-                                            <TooltipTrigger>
-                                                <a
-                                                    href={item.href}
-                                                    target="_blank"
-                                                    rel="noopener noreferrer"
-                                                    className="group ml-1 inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent p-0 text-sm font-medium text-accent-foreground ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
-                                                >
-                                                    <span className="sr-only">{item.title}</span>
-                                                    {item.icon && <Icon iconNode={item.icon} className="size-5 opacity-80 group-hover:opacity-100" />}
-                                                </a>
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                                <p>{item.title}</p>
-                                            </TooltipContent>
-                                        </Tooltip>
-                                    </TooltipProvider>
-                                ))}
-                            </div>
                         </div>
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,10 +1,9 @@
-import { NavFooter } from '@/components/nav-footer';
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
-import { BookOpen, Folder, LayoutGrid, FileText, Users as UsersIcon, List } from 'lucide-react';
+import { LayoutGrid, FileText, Users as UsersIcon, List } from 'lucide-react';
 import AppLogo from './app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -30,18 +29,6 @@ const mainNavItems: NavItem[] = [
     },
 ];
 
-const footerNavItems: NavItem[] = [
-    {
-        title: 'Repository',
-        href: 'https://github.com/laravel/react-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits#react',
-        icon: BookOpen,
-    },
-];
 
 export function AppSidebar() {
     return (
@@ -63,7 +50,6 @@ export function AppSidebar() {
             </SidebarContent>
 
             <SidebarFooter>
-                <NavFooter items={footerNavItems} className="mt-auto" />
                 <NavUser />
             </SidebarFooter>
         </Sidebar>

--- a/resources/js/components/certificate-form.tsx
+++ b/resources/js/components/certificate-form.tsx
@@ -82,7 +82,7 @@ export default function CertificateForm({ onSuccess }: { onSuccess?: () => void 
                 <InputError message={errors.pendaftaran_pertama} />
             </div>
             <div className="flex justify-end gap-2">
-                <Button type="submit" disabled={processing} className="bg-primary hover:bg-primary/90 text-white font-medium rounded-md px-4 py-2 shadow-sm transition">
+                <Button type="submit" disabled={processing} className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-lg px-4 py-2">
                     Save
                 </Button>
             </div>

--- a/resources/js/components/certificate-preview-table.tsx
+++ b/resources/js/components/certificate-preview-table.tsx
@@ -8,23 +8,23 @@ export interface Certificate {
 
 export default function CertificatePreviewTable({ certificates }: { certificates: Certificate[] }) {
     return (
-        <div className="overflow-x-auto bg-white shadow rounded-lg">
-            <table className="min-w-full divide-y divide-gray-200">
-                <thead>
-                    <tr className="bg-gray-50">
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Kode</th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Nama Pemegang</th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">No Sertifikat</th>
-                        <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Luas (m2)</th>
+        <div className="bg-gray-900 rounded-lg shadow overflow-x-auto mx-auto max-w-[calc(100%-2rem)]">
+            <table className="min-w-full divide-y divide-gray-700 text-center">
+                <thead className="bg-gray-800 border-b border-gray-700">
+                    <tr>
+                        <th className="px-6 py-3 text-sm font-semibold text-gray-300">Kode</th>
+                        <th className="px-6 py-3 text-sm font-semibold text-gray-300">Nama Pemegang</th>
+                        <th className="px-6 py-3 text-sm font-semibold text-gray-300">No Sertifikat</th>
+                        <th className="px-6 py-3 text-sm font-semibold text-gray-300">Luas (m2)</th>
                     </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200">
+                <tbody className="divide-y divide-gray-700">
                     {certificates.map((c) => (
-                        <tr key={c.id} className="hover:bg-gray-100">
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.kode}</td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.nama_pemegang}</td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.no_sertifikat}</td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.luas_m2}</td>
+                        <tr key={c.id} className="hover:bg-gray-800">
+                            <td className="px-6 py-4 text-sm text-gray-200">{c.kode}</td>
+                            <td className="px-6 py-4 text-sm text-gray-200">{c.nama_pemegang}</td>
+                            <td className="px-6 py-4 text-sm text-gray-200">{c.no_sertifikat}</td>
+                            <td className="px-6 py-4 text-sm text-gray-200">{c.luas_m2}</td>
                         </tr>
                     ))}
                 </tbody>

--- a/resources/js/components/ui/input.tsx
+++ b/resources/js/components/ui/input.tsx
@@ -3,13 +3,17 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  const isDate = type === "date"
   return (
     <input
       type={type}
       data-slot="input"
+      onClick={isDate ? (e) => (e.currentTarget as HTMLInputElement).showPicker?.() : undefined}
       className={cn(
-        "border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "flex w-full min-w-0 rounded-md",
+        isDate
+          ? "bg-gray-800 text-white placeholder-gray-400 border border-gray-700 px-3 py-2 cursor-pointer"
+          : "border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-9 border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/resources/js/pages/CertificatesIndexPage.tsx
+++ b/resources/js/pages/CertificatesIndexPage.tsx
@@ -55,7 +55,7 @@ export default function CertificatesIndexPage({ certificates, search }: PageProp
                     <DialogTrigger asChild>
                         <Button
                             size="sm"
-                            className="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md font-medium shadow-sm transition"
+                            className="bg-indigo-600 hover:bg-indigo-700 text-white font-medium rounded-lg px-4 py-2"
                         >
                             Add Certificate
                         </Button>
@@ -70,37 +70,37 @@ export default function CertificatesIndexPage({ certificates, search }: PageProp
             </div>
 
             {/* Certificates Table */}
-            <div className="overflow-x-auto bg-white shadow rounded-lg">
-                <table className="min-w-full divide-y divide-gray-200">
-                    <thead>
-                        <tr className="bg-gray-50">
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">No</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Kode</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Nama Pemegang</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Surat Hak</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">No Sertifikat</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Letak Tanah</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Luas (M2)</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Tgl Terbit</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Surat Ukur</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">NIB</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Pendaftaran Pertama</th>
+            <div className="bg-gray-900 rounded-lg shadow overflow-x-auto mx-auto max-w-[calc(100%-2rem)]">
+                <table className="min-w-full divide-y divide-gray-700 text-center">
+                    <thead className="bg-gray-800 border-b border-gray-700">
+                        <tr>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">No</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Kode</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Nama Pemegang</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Surat Hak</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">No Sertifikat</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Letak Tanah</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Luas (M2)</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Tgl Terbit</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Surat Ukur</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">NIB</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Pendaftaran Pertama</th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-200">
+                    <tbody className="divide-y divide-gray-700">
                         {certificates.data.map((c, idx) => (
-                            <tr key={c.id} className="hover:bg-gray-100">
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{idx + 1}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.kode}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.nama_pemegang}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.surat_hak}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.no_sertifikat}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.lokasi_tanah}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.luas_m2}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.tgl_terbit ?? '-'}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.surat_ukur ?? '-'}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.nib ?? '-'}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{c.pendaftaran_pertama ?? '-'}</td>
+                            <tr key={c.id} className="hover:bg-gray-800">
+                                <td className="px-6 py-4 text-sm text-gray-200">{idx + 1}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.kode}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.nama_pemegang}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.surat_hak}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.no_sertifikat}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.lokasi_tanah}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.luas_m2}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.tgl_terbit ?? '-'}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.surat_ukur ?? '-'}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.nib ?? '-'}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{c.pendaftaran_pertama ?? '-'}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/resources/js/pages/LogsIndexPage.tsx
+++ b/resources/js/pages/LogsIndexPage.tsx
@@ -25,21 +25,21 @@ export default function LogsIndexPage({ logs }: PageProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Logs" />
-            <div className="overflow-x-auto bg-white shadow rounded-lg">
-                <table className="min-w-full divide-y divide-gray-200">
-                    <thead>
-                        <tr className="bg-gray-50">
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">User</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Description</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Date</th>
+            <div className="bg-gray-900 rounded-lg shadow overflow-x-auto mx-auto max-w-[calc(100%-2rem)]">
+                <table className="min-w-full divide-y divide-gray-700 text-center">
+                    <thead className="bg-gray-800 border-b border-gray-700">
+                        <tr>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">User</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Description</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Date</th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-200">
+                    <tbody className="divide-y divide-gray-700">
                         {logs.data.map((log) => (
-                            <tr key={log.id} className="hover:bg-gray-100">
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{log.user?.name ?? '-'}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{log.description}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{log.created_at}</td>
+                            <tr key={log.id} className="hover:bg-gray-800">
+                                <td className="px-6 py-4 text-sm text-gray-200">{log.user?.name ?? '-'}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{log.description}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{log.created_at}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/resources/js/pages/UsersIndexPage.tsx
+++ b/resources/js/pages/UsersIndexPage.tsx
@@ -30,23 +30,23 @@ export default function UsersIndexPage({ users }: PageProps) {
                     Add User
                 </Button>
             </div>
-            <div className="overflow-x-auto bg-white shadow rounded-lg">
-                <table className="min-w-full divide-y divide-gray-200">
-                    <thead>
-                        <tr className="bg-gray-50">
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Name</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Email</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Role</th>
-                            <th className="px-6 py-3 text-left text-xs font-semibold text-gray-700 uppercase tracking-wider">Created</th>
+            <div className="bg-gray-900 rounded-lg shadow overflow-x-auto mx-auto max-w-[calc(100%-2rem)]">
+                <table className="min-w-full divide-y divide-gray-700 text-center">
+                    <thead className="bg-gray-800 border-b border-gray-700">
+                        <tr>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Name</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Email</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Role</th>
+                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Created</th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-200">
+                    <tbody className="divide-y divide-gray-700">
                         {users.data.map((u) => (
-                            <tr key={u.id} className="hover:bg-gray-100">
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{u.name}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{u.email}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{u.role}</td>
-                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{u.created_at}</td>
+                            <tr key={u.id} className="hover:bg-gray-800">
+                                <td className="px-6 py-4 text-sm text-gray-200">{u.name}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{u.email}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{u.role}</td>
+                                <td className="px-6 py-4 text-sm text-gray-200">{u.created_at}</td>
                             </tr>
                         ))}
                     </tbody>


### PR DESCRIPTION
## Summary
- restyle certificate tables and forms in dark mode
- update save and add buttons to high-contrast style
- make date inputs high contrast and clickable
- remove repository/documentation links from header and sidebar

## Testing
- `npm run types` *(fails: Cannot find module '@inertiajs/react')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685313d9c570832caf85a5532cf12ab2