### PR TITLE
Implement user modal & table refactor

### DIFF
--- a/resources/js/components/add-user-modal.tsx
+++ b/resources/js/components/add-user-modal.tsx
@@ -1,0 +1,104 @@
+import { router, useForm } from '@inertiajs/react';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+    DialogClose,
+    DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import InputError from '@/components/input-error';
+import { FormEventHandler } from 'react';
+
+export default function AddUserModal() {
+    const { data, setData, post, processing, reset, errors, clearErrors } = useForm({
+        name: '',
+        email: '',
+        password: '',
+        role: 'user',
+    });
+
+    const close = () => {
+        clearErrors();
+        reset();
+    };
+
+    const submit: FormEventHandler = (e) => {
+        e.preventDefault();
+        post(route('users.store'), {
+            onSuccess: () => {
+                close();
+                router.visit(route('users.index'), { preserveScroll: true });
+            },
+        });
+    };
+
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button
+                    size="sm"
+                    className="bg-indigo-500 hover:bg-indigo-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 transition-colors text-white font-medium rounded-lg px-4 py-2"
+                >
+                    Add User
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Add User</DialogTitle>
+                </DialogHeader>
+                <form onSubmit={submit} className="space-y-4">
+                    <div className="grid gap-2">
+                        <Label htmlFor="name">Name</Label>
+                        <Input id="name" value={data.name} onChange={(e) => setData('name', e.target.value)} required />
+                        <InputError message={errors.name} />
+                    </div>
+                    <div className="grid gap-2">
+                        <Label htmlFor="email">Email</Label>
+                        <Input id="email" type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} required />
+                        <InputError message={errors.email} />
+                    </div>
+                    <div className="grid gap-2">
+                        <Label htmlFor="password">Password</Label>
+                        <Input id="password" type="password" value={data.password} onChange={(e) => setData('password', e.target.value)} required />
+                        <InputError message={errors.password} />
+                    </div>
+                    <div className="grid gap-2">
+                        <Label htmlFor="role">Role</Label>
+                        <Select value={data.role} onValueChange={(value) => setData('role', value)}>
+                            <SelectTrigger id="role">
+                                <SelectValue placeholder="Select role" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="admin">Admin</SelectItem>
+                                <SelectItem value="user">User</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <InputError message={errors.role} />
+                    </div>
+                    <DialogFooter className="gap-2">
+                        <DialogClose asChild>
+                            <Button type="button" variant="secondary" onClick={close}>
+                                Cancel
+                            </Button>
+                        </DialogClose>
+                        <Button type="submit" disabled={processing}>
+                            Save
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/resources/js/pages/CertificatesIndexPage.tsx
+++ b/resources/js/pages/CertificatesIndexPage.tsx
@@ -70,37 +70,37 @@ export default function CertificatesIndexPage({ certificates, search }: PageProp
             </div>
 
             {/* Certificates Table */}
-            <div className="bg-gray-900 rounded-lg shadow overflow-x-auto mx-auto max-w-[calc(100%-2rem)]">
-                <table className="min-w-full divide-y divide-gray-700 text-center">
-                    <thead className="bg-gray-800 border-b border-gray-700">
+            <div className="overflow-x-auto">
+                <table className="min-w-full whitespace-nowrap text-sm">
+                    <thead className="bg-primary/10 text-left">
                         <tr>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">No</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Kode</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Nama Pemegang</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Surat Hak</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">No Sertifikat</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Letak Tanah</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Luas (M2)</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Tgl Terbit</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Surat Ukur</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">NIB</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Pendaftaran Pertama</th>
+                            <th className="px-4 py-2">No</th>
+                            <th className="px-4 py-2">Kode</th>
+                            <th className="px-4 py-2">Nama Pemegang</th>
+                            <th className="px-4 py-2">Surat Hak</th>
+                            <th className="px-4 py-2">No Sertifikat</th>
+                            <th className="px-4 py-2">Letak Tanah</th>
+                            <th className="px-4 py-2">Luas (M2)</th>
+                            <th className="px-4 py-2">Tgl Terbit</th>
+                            <th className="px-4 py-2">Surat Ukur</th>
+                            <th className="px-4 py-2">NIB</th>
+                            <th className="px-4 py-2">Pendaftaran Pertama</th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-700">
+                    <tbody className="[&>tr]:odd:bg-primary/5">
                         {certificates.data.map((c, idx) => (
-                            <tr key={c.id} className="hover:bg-gray-800">
-                                <td className="px-6 py-4 text-sm text-gray-200">{idx + 1}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.kode}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.nama_pemegang}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.surat_hak}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.no_sertifikat}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.lokasi_tanah}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.luas_m2}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.tgl_terbit ?? '-'}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.surat_ukur ?? '-'}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.nib ?? '-'}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{c.pendaftaran_pertama ?? '-'}</td>
+                            <tr key={c.id} className="text-center sm:text-left">
+                                <td className="px-4 py-2">{idx + 1}</td>
+                                <td className="px-4 py-2">{c.kode}</td>
+                                <td className="px-4 py-2">{c.nama_pemegang}</td>
+                                <td className="px-4 py-2">{c.surat_hak}</td>
+                                <td className="px-4 py-2">{c.no_sertifikat}</td>
+                                <td className="px-4 py-2">{c.lokasi_tanah}</td>
+                                <td className="px-4 py-2">{c.luas_m2}</td>
+                                <td className="px-4 py-2">{c.tgl_terbit ?? '-'}</td>
+                                <td className="px-4 py-2">{c.surat_ukur ?? '-'}</td>
+                                <td className="px-4 py-2">{c.nib ?? '-'}</td>
+                                <td className="px-4 py-2">{c.pendaftaran_pertama ?? '-'}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/resources/js/pages/LogsIndexPage.tsx
+++ b/resources/js/pages/LogsIndexPage.tsx
@@ -25,21 +25,21 @@ export default function LogsIndexPage({ logs }: PageProps) {
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Logs" />
-            <div className="bg-gray-900 rounded-lg shadow overflow-x-auto mx-auto max-w-[calc(100%-2rem)]">
-                <table className="min-w-full divide-y divide-gray-700 text-center">
-                    <thead className="bg-gray-800 border-b border-gray-700">
+            <div className="overflow-x-auto">
+                <table className="min-w-full whitespace-nowrap text-sm">
+                    <thead className="bg-primary/10 text-left">
                         <tr>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">User</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Description</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Date</th>
+                            <th className="px-4 py-2">User</th>
+                            <th className="px-4 py-2">Description</th>
+                            <th className="px-4 py-2">Date</th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-700">
+                    <tbody className="[&>tr]:odd:bg-primary/5">
                         {logs.data.map((log) => (
-                            <tr key={log.id} className="hover:bg-gray-800">
-                                <td className="px-6 py-4 text-sm text-gray-200">{log.user?.name ?? '-'}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{log.description}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{log.created_at}</td>
+                            <tr key={log.id} className="text-center sm:text-left">
+                                <td className="px-4 py-2">{log.user?.name ?? '-'}</td>
+                                <td className="px-4 py-2">{log.description}</td>
+                                <td className="px-4 py-2">{log.created_at}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/resources/js/pages/UsersIndexPage.tsx
+++ b/resources/js/pages/UsersIndexPage.tsx
@@ -1,7 +1,7 @@
 import AppLayout from '@/layouts/app-layout';
-import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/react';
-import { Button } from '@/components/ui/button';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, usePage } from '@inertiajs/react';
+import AddUserModal from '@/components/add-user-modal';
 
 interface User {
     id: number;
@@ -22,31 +22,30 @@ const breadcrumbs: BreadcrumbItem[] = [
 ];
 
 export default function UsersIndexPage({ users }: PageProps) {
+    const { auth } = usePage<SharedData>().props;
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Users" />
             <div className="flex items-center justify-end mb-6">
-                <Button size="sm" className="bg-primary hover:bg-primary/90 text-white">
-                    Add User
-                </Button>
+                {auth.user.role === 'admin' && <AddUserModal />}
             </div>
-            <div className="bg-gray-900 rounded-lg shadow overflow-x-auto mx-auto max-w-[calc(100%-2rem)]">
-                <table className="min-w-full divide-y divide-gray-700 text-center">
-                    <thead className="bg-gray-800 border-b border-gray-700">
+            <div className="overflow-x-auto">
+                <table className="min-w-full whitespace-nowrap text-sm">
+                    <thead className="bg-primary/10 text-left">
                         <tr>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Name</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Email</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Role</th>
-                            <th className="px-6 py-3 text-sm font-semibold text-gray-300">Created</th>
+                            <th className="px-4 py-2">Name</th>
+                            <th className="px-4 py-2">Email</th>
+                            <th className="px-4 py-2">Role</th>
+                            <th className="px-4 py-2">Created</th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-700">
+                    <tbody className="[&>tr]:odd:bg-primary/5">
                         {users.data.map((u) => (
-                            <tr key={u.id} className="hover:bg-gray-800">
-                                <td className="px-6 py-4 text-sm text-gray-200">{u.name}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{u.email}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{u.role}</td>
-                                <td className="px-6 py-4 text-sm text-gray-200">{u.created_at}</td>
+                            <tr key={u.id} className="text-center sm:text-left">
+                                <td className="px-4 py-2">{u.name}</td>
+                                <td className="px-4 py-2">{u.email}</td>
+                                <td className="px-4 py-2">{u.role}</td>
+                                <td className="px-4 py-2">{u.created_at.slice(0, 10)}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -35,6 +35,7 @@ export interface User {
     id: number;
     name: string;
     email: string;
+    role: string;
     avatar?: string;
     email_verified_at: string | null;
     created_at: string;

--- a/tests/Feature/AdminCanCreateUserViaModalTest.php
+++ b/tests/Feature/AdminCanCreateUserViaModalTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('admin can create user via modal', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    $this->actingAs($admin)
+        ->post('/users', [
+            'name' => 'Modal User',
+            'email' => 'modal@example.com',
+            'password' => 'secret123',
+            'role' => 'user',
+        ])
+        ->assertRedirect(route('users.index', absolute: false));
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'modal@example.com',
+        'name' => 'Modal User',
+        'role' => 'user',
+    ]);
+});


### PR DESCRIPTION
## Summary
- add AddUserModal with form and modal behaviour
- update Users page to use modal and new table styling
- apply responsive table layout to Certificates and Logs pages
- type User role in TS types
- add feature test for creating user via modal

## Testing
- `npm run lint`
- `npm run types`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6853200d9d44832c909de235a20728a9